### PR TITLE
Add e621 flags object to SeachResult site_info

### DIFF
--- a/fuzzysearch-api/src/models.rs
+++ b/fuzzysearch-api/src/models.rs
@@ -91,6 +91,7 @@ pub async fn image_query(
             hashes.searched_hash,
             hashes.distance,
             submission.file_sha256 sha256
+            null flags
         FROM hashes
         JOIN submission ON hashes.found_hash = submission.hash_int
         JOIN artist ON submission.artist_id = artist.id
@@ -109,7 +110,8 @@ pub async fn image_query(
             to_timestamp(data->>'created_at', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') posted_at,
             hashes.searched_hash,
             hashes.distance,
-            e621.sha256
+            e621.sha256,
+            e621.data->>'flags' flags
         FROM hashes
         JOIN e621 ON hashes.found_hash = e621.hash
         WHERE e621.hash IN (SELECT hashes.found_hash)
@@ -128,6 +130,7 @@ pub async fn image_query(
             hashes.searched_hash,
             hashes.distance,
             weasyl.sha256
+            null flags
         FROM hashes
         JOIN weasyl ON hashes.found_hash = weasyl.hash
         WHERE weasyl.hash IN (SELECT hashes.found_hash)
@@ -149,6 +152,7 @@ pub async fn image_query(
             hashes.searched_hash,
             hashes.distance,
             null sha256
+            null flags
         FROM hashes
         JOIN tweet_media ON hashes.found_hash = tweet_media.hash
         JOIN tweet ON tweet_media.tweet_id = tweet.id
@@ -164,6 +168,7 @@ pub async fn image_query(
             },
             Some("e621") => SiteInfo::E621 {
                 sources: row.sources,
+                flags: row.flags,
             },
             Some("Twitter") => SiteInfo::Twitter,
             Some("Weasyl") => SiteInfo::Weasyl,

--- a/fuzzysearch-common/src/types.rs
+++ b/fuzzysearch-common/src/types.rs
@@ -55,6 +55,16 @@ pub struct SearchResult {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct E621Flags {
+    pending: bool,
+    flagged: bool,
+    note_locked: bool,
+    status_locked: bool,
+    rating_locked: bool,
+    deleted: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "site", content = "site_info")]
 pub enum SiteInfo {
     FurAffinity {
@@ -63,6 +73,7 @@ pub enum SiteInfo {
     #[serde(rename = "e621")]
     E621 {
         sources: Option<Vec<String>>,
+        flags: Option<E621Flags>,
     },
     Twitter,
     Weasyl,


### PR DESCRIPTION
### Review Instructions
Pull down and test it out if possible 💚  I've never written or ran Rust before myself 😅 

### Description

This (theoretically) adds e621 flags to the `site_info` search results. 

The e621 flags, outlined [here in the Posts "List" API description](https://e621.net/help/api#posts), are respresented as the following:

```
 - flags (array group)
     - pending If the post is pending approval. (True/False)
     - flagged If the post is flagged for deletion. (True/False)
     - note_locked If the post has it’s notes locked. (True/False)
     - status_locked If the post’s status has been locked. (True/False)
     - rating_locked If the post’s rating has been locked. (True/False)
     - deleted If the post has been deleted. (True/False)
```

I'm not entirely certain what `array group` itself means, but in my working with the e621 API it appears to simply be an object containing booleans, for example:

```
  flags: {
    pending: false,
    flagged: false,
    note_locked: false,
    status_locked: false,
    rating_locked: false,
    deleted: false
  },
```

The reason I'm hoping to add this is that currently while e621 returns whether or not a post has been deleted, there isn't a way to tell that based off of the current `SearchResult` object. I've found that this can result in the top e621 search result being a post that has been deleted, while the list of matching results contains a good match that hasn't been deleted. 

Adding these changes should make it so that when processing the search results, deleted e621 posts could be filtered out.